### PR TITLE
add enable push authentication to menu for push notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 

--- a/app/src/main/java/com/meshcentral/agent/MainActivity.kt
+++ b/app/src/main/java/com/meshcentral/agent/MainActivity.kt
@@ -17,6 +17,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.widget.EditText
 import android.widget.Toast
+import android.provider.Settings
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.PreferenceManager
 import com.google.firebase.installations.FirebaseInstallations
@@ -197,7 +198,9 @@ class MainActivity : AppCompatActivity() {
         var item7 = menu.findItem(R.id.action_testAuth);
         item7.isVisible = false //(visibleScreen == 1) && (serverLink != null);
         var item8 = menu.findItem(R.id.action_settings);
-        item8.isVisible = (visibleScreen == 1)
+        item8.isVisible = (visibleScreen == 1);
+        var item9 = menu.findItem(R.id.action_enablepushauthentication);
+        item9.isVisible = (notificationManager.areNotificationsEnabled() == false);
         return true
     }
 
@@ -244,6 +247,13 @@ class MainActivity : AppCompatActivity() {
         if (item.itemId == R.id.action_settings) {
             // Move to settings screen
             if (mainFragment != null) mainFragment?.moveToSettingsPage()
+        }
+
+        if (item.itemId == R.id.action_enablepushauthentication) {
+            // Ask to Enable Push Notifications for Push Authentication
+            val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+            startActivity(intent)
         }
 
         return when(item.itemId) {

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -33,6 +33,11 @@
         android:title="@string/settings"
         app:showAsAction="never" />
     <item
+        android:id="@+id/action_enablepushauthentication"
+        android:orderInCategory="108"
+        android:title="@string/enablepushauthentication"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/action_close"
         android:orderInCategory="105"
         android:title="@string/close"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,4 +52,5 @@
     <string name="attachment_summary_on">Automatically download attachments for incoming emails
     </string>
     <string name="attachment_summary_off">Only download attachments when manually requested</string>
+    <string name="enablepushauthentication">Enable Push Authentication</string>
 </resources>


### PR DESCRIPTION
Fixes #26

this simple shows the 'Enable push authenication' menu option if your dont have notifications set to allow
then when allowed, the option is hidden